### PR TITLE
Tweak conditions for forward futility pruning to occur

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,866 bytes
+3,861 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,861 bytes
+3,863 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -649,10 +649,8 @@ i32 alphabeta(Position &pos,
             break;
 
         // Forward futility pruning
-        if (depth < 8 && !in_qsearch && !in_check && !(move == tt_move) && static_eval + 100 * depth + gain < alpha) {
-            best_score = alpha;
+        if (depth < 8 && !in_qsearch && !in_check && !(move == tt_move) && static_eval + 100 * depth + gain < alpha)
             break;
-        }
 
         Position npos = pos;
         if (!makemove(npos, move))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -649,7 +649,8 @@ i32 alphabeta(Position &pos,
             break;
 
         // Forward futility pruning
-        if (depth < 8 && !in_qsearch && !in_check && !(move == tt_move) && static_eval + 100 * depth + gain < alpha)
+        if (ply > 0 && depth < 8 && !in_qsearch && !in_check && best_score > -inf &&
+            static_eval + 100 * depth + gain < alpha)
             break;
 
         Position npos = pos;


### PR DESCRIPTION
Passed STC (accidentally tested at [0, 5] but passed [-3, 1]):
```
ELO   | 1.63 +- 2.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 5.70 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 48912 W: 13734 L: 13504 D: 21674
```
http://chess.grantnet.us/test/33724/

Passed LTC:
```
ELO   | 4.42 +- 4.50 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 11712 W: 3074 L: 2925 D: 5713
```
http://chess.grantnet.us/test/33726/

-3 bytes

Bench: 5944976